### PR TITLE
Markov chain scripts

### DIFF
--- a/bin/blocks-continue
+++ b/bin/blocks-continue
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 from argparse import ArgumentParser
-import sys
 
-import dill
-
+from blocks.scripts import continue_training
 
 if __name__ == "__main__":
     parser = ArgumentParser("Continues your pickled main loop")
@@ -13,7 +11,4 @@ if __name__ == "__main__":
         "--rec-limit", type=int, help="The recursion depth limit")
     args = parser.parse_args()
 
-    if args.rec_limit:
-        sys.setrecursionlimit(args.rec_limit)
-    main_loop = dill.load(open(args.path, "rb"))
-    main_loop.run()
+    continue_training(args.path, args.rec_limit)

--- a/blocks/scripts.py
+++ b/blocks/scripts.py
@@ -1,0 +1,10 @@
+import sys
+
+import dill
+
+
+def continue_training(path, rec_limit=None):
+    if rec_limit:
+        sys.setrecursionlimit(rec_limit)
+    main_loop = dill.load(open(path, "rb"))
+    main_loop.run()

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(
         'Programming Language :: Python :: 3.4',
     ],
     keywords='theano machine learning neural networks deep learning',
-    packages=find_packages(exclude=['docs', 'tests']),
+    packages=find_packages(exclude=['examples', 'docs', 'tests']),
+    scripts=['bin/blocks-continue'],
     install_requires=['dill', 'numpy', 'theano', 'six'],
     extras_require={
         'test': ['nose', 'nose2'],

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,7 +1,6 @@
 import logging
 import os
 
-import pylearn2
 import dill
 
 import blocks
@@ -10,10 +9,6 @@ from examples.markov_chain.main import main as markov_chain_test
 
 
 def setup():
-    # Silence Pylearn2's logger
-    logger = logging.getLogger(pylearn2.__name__)
-    logger.setLevel(logging.ERROR)
-
     # Silence Block's logger
     logger = logging.getLogger(blocks.__name__)
     logger.setLevel(logging.ERROR)
@@ -38,18 +33,3 @@ def test_markov_chain():
     os.remove(filename)
 
 test_mnist.setup = setup
-
-
-def test_pylearn2():
-    # This test is currenly off due to problems with PyLearn2
-    # serialization.
-    # filename = 'unittest_markov_chain'
-    # try:
-        # pylearn2_test('train', filename, 0, 3, False)
-    # except OSError:
-    #     from unittest import SkipTest
-    #     raise SkipTest
-    # os.remove(filename)
-    pass
-
-test_pylearn2.setup = setup


### PR DESCRIPTION
For some reason it shows up as me having deleted and recreated the file when moving main.py -> __init__.py. I think this has to do with file permissions; the scripts should probably be executable, but only `mnist.py` and `markov_chain/__init__.py` are right now. I'll make a ticket for the rest.